### PR TITLE
release: prepare 1.4.1-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
     "test:watch": "vitest"
   },
   "type": "module",
-  "version": "1.4.1-beta.2"
+  "version": "1.4.1-beta.3"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "1.4.1-beta.2"
+version = "1.4.1-beta.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "1.4.1-beta.2"
+version = "1.4.1-beta.3"
 description = "A decentralized P2P chat application with local-first data and permission-based sharing"
 authors = ["Harbor Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,5 +50,5 @@
     }
   },
   "productName": "Harbor",
-  "version": "1.4.1-beta.2"
+  "version": "1.4.1-beta.3"
 }


### PR DESCRIPTION
Prepare the branded Harbor beta release after merging the brand refresh, theme system, and updater experience.