### PR TITLE
release: prepare 1.4.1-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
     "test:watch": "vitest"
   },
   "type": "module",
-  "version": "1.4.1-beta.3"
+  "version": "1.4.1-beta.4"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "1.4.1-beta.3"
+version = "1.4.1-beta.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "1.4.1-beta.3"
+version = "1.4.1-beta.4"
 description = "A decentralized P2P chat application with local-first data and permission-based sharing"
 authors = ["Harbor Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,5 +50,5 @@
     }
   },
   "productName": "Harbor",
-  "version": "1.4.1-beta.3"
+  "version": "1.4.1-beta.4"
 }


### PR DESCRIPTION
Prepare refreshed platform binaries containing the scalable Harbor desktop icon and avatar styling polish.