### PR TITLE
Release Harbor 1.4.1-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "test:watch": "vitest"
   },
   "type": "module",
-  "version": "1.4.1-beta.4"
+  "version": "1.4.1-beta.5"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "1.4.1-beta.4"
+version = "1.4.1-beta.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "1.4.1-beta.4"
+version = "1.4.1-beta.5"
 description = "A decentralized P2P chat application with local-first data and permission-based sharing"
 authors = ["Harbor Contributors"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,5 +46,5 @@
     }
   },
   "productName": "Harbor",
-  "version": "1.4.1-beta.4"
+  "version": "1.4.1-beta.5"
 }


### PR DESCRIPTION
## What changed

- bump the frontend package version to 1.4.1-beta.5
- synchronize the Tauri and Rust package versions
- prepare fresh installers containing the final UX and account chooser fixes

## Validation

- `pnpm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`