### PR TITLE
Sign Windows builds and add Harbor title bar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release-validation:
@@ -197,7 +198,8 @@ jobs:
           "TAURI_SIGNING_PRIVATE_KEY=$key" >> $env:GITHUB_ENV
           "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=$(op read 'op://bako/TAURI_SIGNING_PRIVATE_KEY_PASSWORD/password')" >> $env:GITHUB_ENV
 
-      - name: Build Tauri app
+      - name: Build non-Windows Tauri app
+        if: runner.os != 'Windows'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -205,10 +207,98 @@ jobs:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}
 
+      - name: Azure login for Artifact Signing
+        if: runner.os == 'Windows'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
+
+      - name: Build Windows executable
+        if: runner.os == 'Windows'
+        run: pnpm tauri build --no-bundle
+
+      - name: Sign Windows executable
+        if: runner.os == 'Windows'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: social-harbor
+          certificate-profile-name: social-harbor
+          files: ${{ github.workspace }}\src-tauri\target\release\harbor.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: Harbor
+          description-url: https://harbor.social
+
+      - name: Bundle signed Windows executable
+        if: runner.os == 'Windows'
+        run: pnpm tauri bundle --bundles nsis
+
+      - name: Sign Windows installer
+        if: runner.os == 'Windows'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: social-harbor
+          certificate-profile-name: social-harbor
+          files: ${{ github.workspace }}\src-tauri\target\release\bundle\nsis\Harbor_${{ needs.create-release.outputs.version }}_x64-setup.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: Harbor
+          description-url: https://harbor.social
+
+      - name: Verify and sign Windows updater artifact
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $installer = "src-tauri/target/release/bundle/nsis/Harbor_${{ needs.create-release.outputs.version }}_x64-setup.exe"
+          $signature = Get-AuthenticodeSignature $installer
+          if ($signature.Status -ne 'Valid') {
+            throw "Windows installer Authenticode status is $($signature.Status): $($signature.StatusMessage)"
+          }
+          pnpm tauri signer sign $installer
+
+      - name: Upload signed Windows updater artifacts
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $bundle = "src-tauri/target/release/bundle/nsis"
+          gh release upload "v${{ needs.create-release.outputs.version }}" `
+            "$bundle/Harbor_${{ needs.create-release.outputs.version }}_x64-setup.exe" `
+            "$bundle/Harbor_${{ needs.create-release.outputs.version }}_x64-setup.exe.sig" `
+            --clobber
+
   publish-release:
     needs: [create-release, build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Finalize updater manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.create-release.outputs.version }}
+        run: |
+          mkdir -p release-assets
+          gh release download "v${VERSION}" \
+            --pattern latest.json \
+            --pattern "Harbor_${VERSION}_x64-setup.exe.sig" \
+            --dir release-assets
+          node scripts/finalize-updater-manifest.mjs \
+            release-assets/latest.json \
+            "${VERSION}" \
+            "release-assets/Harbor_${VERSION}_x64-setup.exe.sig" \
+            release-assets/final-latest.json
+          mv release-assets/final-latest.json release-assets/latest.json
+          gh release upload "v${VERSION}" release-assets/latest.json --clobber
+          gh release upload updater-channel release-assets/latest.json --clobber
+
       - name: Publish release
         uses: actions/github-script@v7
         with:

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "test:watch": "vitest"
   },
   "type": "module",
-  "version": "1.4.1-beta.5"
+  "version": "1.4.1-beta.6"
 }

--- a/scripts/finalize-updater-manifest.mjs
+++ b/scripts/finalize-updater-manifest.mjs
@@ -1,0 +1,34 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const [inputPath, version, windowsSignaturePath, outputPath] = process.argv.slice(2);
+
+if (!inputPath || !version || !windowsSignaturePath || !outputPath) {
+  throw new Error(
+    'Usage: node scripts/finalize-updater-manifest.mjs <manifest> <version> <windows-signature> <output>',
+  );
+}
+
+const manifest = JSON.parse(await readFile(inputPath, 'utf8'));
+const windowsSignature = (await readFile(windowsSignaturePath, 'utf8')).trim();
+const releaseBase = `https://github.com/Bakobiibizo/harbor/releases/download/v${version}`;
+const windowsUrl = `${releaseBase}/Harbor_${version}_x64-setup.exe`;
+
+for (const platform of Object.values(manifest.platforms ?? {})) {
+  if (typeof platform.url === 'string') {
+    platform.url = platform.url.replace(
+      'https://github.com/Bakobiibizo/harbor/releases/latest/download',
+      releaseBase,
+    );
+  }
+}
+
+manifest.platforms['windows-x86_64'] = {
+  signature: windowsSignature,
+  url: windowsUrl,
+};
+manifest.platforms['windows-x86_64-nsis'] = {
+  signature: windowsSignature,
+  url: windowsUrl,
+};
+
+await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "harbor"
-version = "1.4.1-beta.5"
+version = "1.4.1-beta.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harbor"
-version = "1.4.1-beta.5"
+version = "1.4.1-beta.6"
 description = "A decentralized P2P chat application with local-first data and permission-based sharing"
 authors = ["Harbor Contributors"]
 license = "MIT"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging",
     "opener:default",
     "updater:default",
     "process:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,5 +46,5 @@
     }
   },
   "productName": "Harbor",
-  "version": "1.4.1-beta.5"
+  "version": "1.4.1-beta.6"
 }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "decorations": false,
+        "height": 800,
+        "minHeight": 600,
+        "minWidth": 800,
+        "shadow": true,
+        "title": "Harbor",
+        "width": 1200
+      }
+    ]
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,15 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Full-screen flows fill the client area beneath Harbor's Windows title bar. */
+.harbor-app-content .min-h-screen {
+  min-height: 100%;
+}
+
+.harbor-app-content .h-screen {
+  height: 100%;
+}
+
 /* ============================================
    Typography Helpers
    ============================================ */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import toast, { Toaster } from 'react-hot-toast';
 import { isTauri } from '@tauri-apps/api/core';
 import { useIdentityStore, useNetworkStore, useSettingsStore, useAccountsStore } from './stores';
 import { useTauriEvents } from './hooks';
-import { MainLayout } from './components/layout';
+import { MainLayout, WindowsTitleBar } from './components/layout';
 import { AccountSelection, CreateIdentity, UnlockIdentity } from './components/onboarding';
 import { LegacyIdentityMigration } from './components/identity';
 import { AddContactDialog, ErrorBoundary } from './components/common';
@@ -236,10 +236,17 @@ function AppContent() {
 }
 
 export default function App() {
+  const showWindowsTitleBar = isTauri() && /Windows/i.test(navigator.userAgent);
+
   return (
     <ErrorBoundary>
       <HashRouter>
-        <AppContent />
+        <div className="flex h-screen flex-col overflow-hidden">
+          {showWindowsTitleBar && <WindowsTitleBar />}
+          <div className="harbor-app-content min-h-0 flex-1 overflow-hidden">
+            <AppContent />
+          </div>
+        </div>
         <Toaster
           position="bottom-right"
           toastOptions={{

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -124,7 +124,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   };
 
   return (
-    <div className="flex h-screen" style={{ background: 'hsl(var(--harbor-bg-primary))' }}>
+    <div className="flex h-full min-h-0" style={{ background: 'hsl(var(--harbor-bg-primary))' }}>
       {/* Sidebar */}
       <aside
         className="w-72 flex flex-col border-r"

--- a/src/components/layout/WindowsTitleBar.test.tsx
+++ b/src/components/layout/WindowsTitleBar.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WindowsTitleBar } from './WindowsTitleBar';
+
+const h = vi.hoisted(() => ({
+  close: vi.fn(async () => undefined),
+  isMaximized: vi.fn(async () => false),
+  minimize: vi.fn(async () => undefined),
+  onResized: vi.fn(async () => vi.fn()),
+  toggleMaximize: vi.fn(async () => undefined),
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => h,
+}));
+
+describe('WindowsTitleBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.isMaximized.mockResolvedValue(false);
+    h.onResized.mockResolvedValue(vi.fn());
+  });
+
+  it('uses Harbor branding and exposes native window controls', async () => {
+    render(<WindowsTitleBar />);
+
+    expect(screen.getByText('Harbor')).toBeInTheDocument();
+    expect(screen.getByText('Private beta')).toBeInTheDocument();
+    await waitFor(() => expect(h.isMaximized).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Minimize Harbor' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize Harbor' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close Harbor' }));
+
+    expect(h.minimize).toHaveBeenCalledOnce();
+    expect(h.toggleMaximize).toHaveBeenCalledOnce();
+    expect(h.close).toHaveBeenCalledOnce();
+  });
+
+  it('shows the restore control when the window is maximized', async () => {
+    h.isMaximized.mockResolvedValue(true);
+
+    render(<WindowsTitleBar />);
+
+    expect(
+      await screen.findByRole('button', { name: 'Restore Harbor window' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/WindowsTitleBar.tsx
+++ b/src/components/layout/WindowsTitleBar.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { HarborIcon } from '../icons';
+
+const appWindow = getCurrentWindow();
+
+export function WindowsTitleBar() {
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    const syncWindowState = async () => {
+      setIsMaximized(await appWindow.isMaximized());
+    };
+
+    void syncWindowState();
+    void appWindow.onResized(syncWindowState).then((stopListening) => {
+      unlisten = stopListening;
+    });
+
+    return () => unlisten?.();
+  }, []);
+
+  return (
+    <header
+      data-tauri-drag-region
+      className="h-10 flex shrink-0 select-none items-center border-b"
+      style={{
+        background: 'hsl(var(--harbor-bg-elevated))',
+        borderColor: 'hsl(var(--harbor-border-subtle))',
+      }}
+      onDoubleClick={() => void appWindow.toggleMaximize()}
+    >
+      <div data-tauri-drag-region className="flex min-w-0 flex-1 items-center gap-2.5 px-3">
+        <HarborIcon className="h-5 w-5 shrink-0" />
+        <span
+          data-tauri-drag-region
+          className="truncate text-sm font-semibold tracking-wide"
+          style={{ color: 'hsl(var(--harbor-text-primary))' }}
+        >
+          Harbor
+        </span>
+        <span
+          data-tauri-drag-region
+          className="rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em]"
+          style={{
+            background: 'hsl(var(--harbor-primary) / 0.12)',
+            color: 'hsl(var(--harbor-primary))',
+          }}
+        >
+          Private beta
+        </span>
+      </div>
+
+      <div className="flex h-full" onDoubleClick={(event) => event.stopPropagation()}>
+        <button
+          type="button"
+          className="group grid h-full w-12 place-items-center transition-colors hover:bg-white/5"
+          aria-label="Minimize Harbor"
+          title="Minimize"
+          onClick={() => void appWindow.minimize()}
+        >
+          <svg
+            aria-hidden="true"
+            className="h-3.5 w-3.5"
+            viewBox="0 0 16 16"
+            style={{ color: 'hsl(var(--harbor-text-secondary))' }}
+          >
+            <path d="M3 8.5h10v1H3z" fill="currentColor" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="group grid h-full w-12 place-items-center transition-colors hover:bg-white/5"
+          aria-label={isMaximized ? 'Restore Harbor window' : 'Maximize Harbor'}
+          title={isMaximized ? 'Restore' : 'Maximize'}
+          onClick={() => void appWindow.toggleMaximize()}
+        >
+          <svg
+            aria-hidden="true"
+            className="h-3.5 w-3.5"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            style={{ color: 'hsl(var(--harbor-text-secondary))' }}
+          >
+            {isMaximized ? (
+              <>
+                <path d="M5.5 5.5h7v7h-7z" />
+                <path d="M3.5 10.5v-7h7" />
+              </>
+            ) : (
+              <path d="M3.5 3.5h9v9h-9z" />
+            )}
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="group grid h-full w-12 place-items-center transition-colors hover:bg-red-600"
+          aria-label="Close Harbor"
+          title="Close"
+          onClick={() => void appWindow.close()}
+        >
+          <svg
+            aria-hidden="true"
+            className="h-3.5 w-3.5"
+            viewBox="0 0 16 16"
+            stroke="currentColor"
+            style={{ color: 'hsl(var(--harbor-text-secondary))' }}
+          >
+            <path d="m3.5 3.5 9 9m0-9-9 9" />
+          </svg>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,1 +1,2 @@
 export { MainLayout } from './MainLayout';
+export { WindowsTitleBar } from './WindowsTitleBar';


### PR DESCRIPTION
## What changed

- add a Harbor-styled Windows title bar with native window controls
- disable native Windows decorations only on Windows
- build and Authenticode-sign both the app executable and NSIS installer through Azure Artifact Signing
- regenerate the Tauri updater signature after Authenticode signing
- publish versioned updater URLs and refresh the updater channel automatically
- bump the release to 1.4.1-beta.6

## Why

The beta.5 `.sig` was an updater-integrity signature, not an embedded Windows Authenticode signature, so SmartScreen still warned. The updater manifest also referenced assets on the manifest-only latest channel.

## Validation

- TypeScript type-check
- 50 frontend test files / 411 tests
- production updater manifest finalized against the real beta.5 assets
- release workflow YAML parsed and formatted
- Azure signing is verified in-workflow with `Get-AuthenticodeSignature` before upload