### PR TITLE
Allow profile-scoped Azure signing login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,7 @@ jobs:
           client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Build Windows executable
         if: runner.os == 'Windows'


### PR DESCRIPTION
## What changed

Allow Azure OIDC login without requiring a subscription-level Reader assignment.

## Why

The Harbor signing identity authenticates successfully and has the narrowly scoped Artifact Signing Certificate Profile Signer role, but Azure Login stopped with `No subscriptions found`. Artifact Signing does not require broad subscription read access.

## Validation

- release workflow YAML parses successfully
- Prettier check passes
- the signing action remains gated by its profile-scoped Azure role