### PR TITLE
Use tenant-scoped Azure login for signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,6 @@ jobs:
         with:
           client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
           allow-no-subscriptions: true
 
       - name: Build Windows executable


### PR DESCRIPTION
## What changed

Remove the Azure subscription selector from the Artifact Signing login while retaining `allow-no-subscriptions`.

## Why

OIDC authentication succeeds, but Azure Login attempts to select the supplied subscription even though the signing identity intentionally has no subscription-level Reader assignment. Artifact Signing authorization is scoped directly to the certificate profile.

## Validation

- release workflow YAML parses successfully
- Prettier check passes
- preserves least-privilege profile authorization